### PR TITLE
Disable S3 static website hosting so CDK creates an origin access identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sightsoundtheatres/cdk-sightsound-fe",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Frontend construct for sight and sound apps",
   "main": "stack.js",
   "publishConfig": {

--- a/stack.ts
+++ b/stack.ts
@@ -40,7 +40,6 @@ export class FrontendConstruct extends Construct {
 
     // Content bucket
     const siteBucket = new s3.Bucket(this, 'SiteBucket', {
-      websiteIndexDocument: 'index.html',
       removalPolicy: RemovalPolicy.DESTROY,
       encryption: s3.BucketEncryption.S3_MANAGED
     });
@@ -54,7 +53,7 @@ export class FrontendConstruct extends Construct {
       new CfnOutput(this, 'Certificate', { value: this.certificate.certificateArn });
     }
 
-    const origin = new cloudfrontOrigins.S3Origin(siteBucket, {});
+    const origin = new cloudfrontOrigins.S3Origin(siteBucket);
 
     const responseHeadersPolicy = new cloudfront.ResponseHeadersPolicy(this, 'CloudFrontResponseHeaders', {
       securityHeadersBehavior: {


### PR DESCRIPTION
New `Distribution` construct depends on if there is a static website configured or not. We don't use this feature of S3, so fixing