### PR TITLE
Don't cache ngsw.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sightsoundtheatres/cdk-sightsound-fe",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Frontend construct for sight and sound apps",
   "main": "stack.js",
   "scripts": {

--- a/stack.ts
+++ b/stack.ts
@@ -50,6 +50,7 @@ export class FrontendConstruct extends Construct {
       'robots.txt',
       'favicon.ico',
       'config.json',
+      'ngsw.json'
     ];
 
     // Content bucket


### PR DESCRIPTION
In the compiled code and the [service worker failsafe](https://angular.io/guide/service-worker-devops#fail-safe), ngsw.json is the file to bypass for caching to ensure that the most up to date app versions are served

![Screenshot 2023-10-03 at 9 39 36 AM](https://github.com/sightsoundtheatres/cdk-sightsound-fe/assets/13950101/e519e64a-bfdc-48e2-ae60-24276e357257)
