### PR TITLE
Add versioned to s3 deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sightsoundtheatres/cdk-sightsound-fe",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Frontend construct for sight and sound apps",
   "main": "stack.js",
   "scripts": {

--- a/stack.ts
+++ b/stack.ts
@@ -58,6 +58,17 @@ export class FrontendConstruct extends Construct {
       removalPolicy: RemovalPolicy.DESTROY,
       encryption: s3.BucketEncryption.S3_MANAGED,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      versioned: true,
+      intelligentTieringConfigurations: [{
+        name: 'auto-tier-non-current-site-assets',
+        archiveAccessTierTime: Duration.days(90),
+        deepArchiveAccessTierTime: Duration.days(180),
+      }],
+      lifecycleRules: [{
+        id: 'delete-old-versions',
+        expiration: Duration.days(2555),
+        noncurrentVersionsToRetain: 6
+      }]
     });
 
     if (props.domainNames) {
@@ -178,6 +189,7 @@ export class FrontendConstruct extends Construct {
         s3deploy.CacheControl.maxAge(Duration.days(365)),
         s3deploy.CacheControl.fromString('immutable'),
       ],
+      prune: false,
     });
 
     const noCacheDeployment = new s3deploy.BucketDeployment(


### PR DESCRIPTION
This versioning to the s3 deployment.

- I enabled intelligent tiering, cause why not.
- I set assets to expire in 7 years so they will be deleted after that
- Set it to only keep 6 previous versions to match the BE deployment.